### PR TITLE
use correct framework

### DIFF
--- a/hello-world/helloworld.csproj
+++ b/hello-world/helloworld.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp8.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>helloworld</RootNamespace>
   </PropertyGroup>
 

--- a/hello-world/obj/helloworld.csproj.nuget.dgspec.json
+++ b/hello-world/obj/helloworld.csproj.nuget.dgspec.json
@@ -17,14 +17,13 @@
           "/root/.nuget/NuGet/NuGet.Config"
         ],
         "originalTargetFrameworks": [
-          "netcoreapp8.0"
+          "net8.0"
         ],
         "sources": {
           "https://api.nuget.org/v3/index.json": {}
         },
         "frameworks": {
           "net8.0": {
-            "targetAlias": "netcoreapp8.0",
             "projectReferences": {}
           }
         },
@@ -41,7 +40,6 @@
       },
       "frameworks": {
         "net8.0": {
-          "targetAlias": "netcoreapp8.0",
           "imports": [
             "net461",
             "net462",

--- a/hello-world/obj/project.assets.json
+++ b/hello-world/obj/project.assets.json
@@ -23,14 +23,13 @@
         "/root/.nuget/NuGet/NuGet.Config"
       ],
       "originalTargetFrameworks": [
-        "netcoreapp8.0"
+        "net8.0"
       ],
       "sources": {
         "https://api.nuget.org/v3/index.json": {}
       },
       "frameworks": {
         "net8.0": {
-          "targetAlias": "netcoreapp8.0",
           "projectReferences": {}
         }
       },
@@ -47,7 +46,6 @@
     },
     "frameworks": {
       "net8.0": {
-        "targetAlias": "netcoreapp8.0",
         "imports": [
           "net461",
           "net462",


### PR DESCRIPTION
the undocumented names (without period in dotnet 5+) can drop their support when move to double-digit (to avoid potential conflicts) [learn.microsoft.com/en-us/dotnet/standard/frameworks#supported-target-frameworks](https://learn.microsoft.com/en-us/dotnet/standard/frameworks#supported-target-frameworks)